### PR TITLE
Add GitHub contributions graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,15 @@ Ngā mihi nui!
 ![Bash](https://img.shields.io/badge/GNU_Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
 
 ### 📈 Statistics
-[![James' GitHub Contributions](https://github.pumbas.net/api/contributions/JamesNZL)](https://github.com/pumbas600/github-contributions)
-
 [![Top languages](https://github-readme-stats-sigma-sable.vercel.app/api/top-langs/?username=jamesnzl&count_private=true&theme=default&layout=compact&card_width=305&langs_count=12&hide=tex&exclude_repo=compsys301-line-following-robot,softeng281-money,softeng281-blackjack,Order-Bot,AoC-2020#gh-light-mode-only)](https://jamesnzl.xyz#gh-light-mode-only)
 [![Top languages](https://github-readme-stats-sigma-sable.vercel.app/api/top-langs/?username=jamesnzl&count_private=true&theme=react&layout=compact&card_width=305&langs_count=12&hide_border=true&hide=tex&exclude_repo=compsys301-line-following-robot,softeng281-money,softeng281-blackjack,Order-Bot,AoC-2020#gh-dark-mode-only)](https://jamesnzl.xyz#gh-dark-mode-only)  
 [![GitHub stats](https://github-readme-stats-sigma-sable.vercel.app/api?username=jamesnzl&count_private=true&show_icons=true&theme=default&card_width=305&hide_rank=true#gh-light-mode-only)](https://jamesnzl.xyz#gh-light-mode-only)
 [![GitHub stats](https://github-readme-stats-sigma-sable.vercel.app/api?username=jamesnzl&count_private=true&show_icons=true&theme=react&card_width=305&hide_border=true&hide_rank=true#gh-dark-mode-only)](https://jamesnzl.xyz#gh-dark-mode-only)  
 [![GitHub streak stats](https://github-readme-streak-stats.herokuapp.com?user=jamesnzl&theme=default&fire=2f80ed&ring=2f80ed&currStreakLabel=2f80ed&sideNums=2f80ed&date_format=j%20M%5B%20Y%5D#gh-light-mode-only)](https://jamesnzl.xyz#gh-light-mode-only)
-[![GitHub streak stats](https://github-readme-streak-stats.herokuapp.com?user=jamesnzl&theme=react&hide_border=true&date_format=j%20M%5B%20Y%5D#gh-dark-mode-only)](https://jamesnzl.xyz#gh-dark-mode-only)
+[![GitHub streak stats](https://github-readme-streak-stats.herokuapp.com?user=jamesnzl&theme=react&hide_border=true&date_format=j%20M%5B%20Y%5D#gh-dark-mode-only)](https://jamesnzl.xyz#gh-dark-mode-only)  
+[![GitHub contributions graph](https://github.pumbas.net/api/contributions/JamesNZL?colour=2f80ed&bgColour=fffefe#gh-light-mode-only)](https://github.com/pumbas600/github-contributions#gh-light-mode-only)  
+[![GitHub contributions graph](https://github.pumbas.net/api/contributions/JamesNZL?colour=61dafb&bgColour=20232a#gh-dark-mode-only)](https://github.com/pumbas600/github-contributions#gh-dark-mode-only)
+
 
 ### 💬 Discord
 [![nzl.james](https://lanyard.cnrad.dev/api/192181901065322496?theme=light&hideDiscrim=true&idleMessage=Twiddling%20my%20thumbs...#gh-light-mode-only)](https://discord.com/users/192181901065322496#gh-light-mode-only)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Ngā mihi nui!
 ![Bash](https://img.shields.io/badge/GNU_Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
 
 ### 📈 Statistics
+[![James' GitHub Contributions](https://github.pumbas.net/api/contributions/JamesNZL)](https://github.com/pumbas600/github-contributions)
+
 [![Top languages](https://github-readme-stats-sigma-sable.vercel.app/api/top-langs/?username=jamesnzl&count_private=true&theme=default&layout=compact&card_width=305&langs_count=12&hide=tex&exclude_repo=compsys301-line-following-robot,softeng281-money,softeng281-blackjack,Order-Bot,AoC-2020#gh-light-mode-only)](https://jamesnzl.xyz#gh-light-mode-only)
 [![Top languages](https://github-readme-stats-sigma-sable.vercel.app/api/top-langs/?username=jamesnzl&count_private=true&theme=react&layout=compact&card_width=305&langs_count=12&hide_border=true&hide=tex&exclude_repo=compsys301-line-following-robot,softeng281-money,softeng281-blackjack,Order-Bot,AoC-2020#gh-dark-mode-only)](https://jamesnzl.xyz#gh-dark-mode-only)  
 [![GitHub stats](https://github-readme-stats-sigma-sable.vercel.app/api?username=jamesnzl&count_private=true&show_icons=true&theme=default&card_width=305&hide_rank=true#gh-light-mode-only)](https://jamesnzl.xyz#gh-light-mode-only)


### PR DESCRIPTION
[![James' GitHub Contributions](https://github.pumbas.net/api/contributions/JamesNZL)](https://github.com/pumbas600/github-contributions)
*This is the exact markdown I have added to your README*


I'm not sure if you like the default styling. The background is transparent and the colour is meant to be okay in both light and dark mode. You can customise it more with the options here though: https://github.com/pumbas600/github-contributions#customisation